### PR TITLE
Rename "initial" to "idle"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@principlestudios/loadable",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple loadable construct",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/loadable/filters.ts
+++ b/src/loadable/filters.ts
@@ -1,5 +1,5 @@
 import { errorType, LoadableError } from './error';
-import { initial, Initial } from './initial';
+import { idle, Idle } from './idle';
 import { Loaded, loadedType } from './loaded';
 import { Loading, loadingType } from './loading';
 import { Loadable } from './loadable';
@@ -8,8 +8,8 @@ export function isLoaded<T>(thing: Loadable<T>): thing is Loaded<T> {
 	return thing.type === loadedType;
 }
 
-export function isInitial(thing: Loadable<unknown>): thing is Initial {
-	return thing === initial;
+export function isIdle(thing: Loadable<unknown>): thing is Idle {
+	return thing === idle;
 }
 
 export function isLoading<T>(thing: Loadable<T>): thing is Loading<T> {

--- a/src/loadable/idle.ts
+++ b/src/loadable/idle.ts
@@ -1,0 +1,6 @@
+const idleSymbol = 'idle';
+export const idle = Object.freeze({ type: idleSymbol } as const);
+export type Idle = typeof idle;
+export function makeIdle(): Idle {
+	return idle;
+}

--- a/src/loadable/index.ts
+++ b/src/loadable/index.ts
@@ -1,5 +1,5 @@
 export * from './error';
-export * from './initial';
+export * from './idle';
 export * from './loading';
 export * from './loaded';
 export * from './loadable';

--- a/src/loadable/initial.ts
+++ b/src/loadable/initial.ts
@@ -1,6 +1,0 @@
-const initialSymbol = 'initial';
-export const initial = Object.freeze({ type: initialSymbol } as const);
-export type Initial = typeof initial;
-export function makeInitial(): Initial {
-	return initial;
-}

--- a/src/loadable/loadable.ts
+++ b/src/loadable/loadable.ts
@@ -1,6 +1,6 @@
 import type { LoadableError } from './error';
-import type { Initial } from './initial';
+import type { Idle } from './idle';
 import type { Loaded } from './loaded';
 import type { Loading } from './loading';
 
-export type Loadable<T> = Loading<T> | LoadableError | Loaded<T> | Initial;
+export type Loadable<T> = Loading<T> | LoadableError | Loaded<T> | Idle;

--- a/src/map-loadable-value.ts
+++ b/src/map-loadable-value.ts
@@ -1,9 +1,9 @@
 import { mapLoadable } from './map-loadable';
-import { makeError, makeInitial, makeLoaded, makeLoading, Loadable } from './loadable';
+import { makeError, makeIdle, makeLoaded, makeLoading, Loadable } from './loadable';
 
 export function mapLoadableValue<T, TResult>(target: Loadable<T>, convert: (input: T) => TResult): Loadable<TResult> {
 	return mapLoadable<T, Loadable<TResult>>(target, {
-		initial: makeInitial,
+		idle: makeIdle,
 		loading: (value) => makeLoading(value === undefined ? undefined : convert(value)),
 		loaded: (value) => makeLoaded(convert(value)),
 		error: makeError,

--- a/src/map-loadable.ts
+++ b/src/map-loadable.ts
@@ -1,22 +1,22 @@
 import { neverEver } from 'src/internal/never-ever';
-import { isError, isInitial, isLoaded, isLoading, Loadable } from './loadable';
+import { isError, isIdle, isLoaded, isLoading, Loadable } from './loadable';
 
 export function mapLoadable<TInput, TResult>(
 	thing: Loadable<TInput>,
 	{
-		initial: whenInitial,
+		idle: whenIdle,
 		loading: whenLoading,
 		loaded: whenLoaded,
 		error: whenError,
 	}: {
-		initial?: () => TResult;
+		idle?: () => TResult;
 		loading: (value?: TInput) => TResult;
 		loaded: (value: TInput) => TResult;
 		error: (error?: unknown) => TResult;
 	}
 ): TResult {
 	if (isLoading(thing)) return whenLoading(thing.value);
-	if (isInitial(thing)) return (whenInitial || whenLoading)();
+	if (isIdle(thing)) return (whenIdle || whenLoading)();
 	if (isError(thing)) return whenError(thing.error);
 	if (isLoaded(thing)) return whenLoaded(thing.value);
 	return neverEver(thing);


### PR DESCRIPTION
Per #4, "idle" is a more industry-standard way of naming this state - no value is available, and no work is being/has been done to ensure such a value.